### PR TITLE
Correct a spelling mistake in the cppguide

### DIFF
--- a/cppguide.html
+++ b/cppguide.html
@@ -1500,7 +1500,7 @@ creating objects of user-defined types.</p>
   operations.</li>
 
   <li>Finding the call sites for overloaded operators may
-  requre a search tool that's aware of C++ syntax, rather
+  require a search tool that's aware of C++ syntax, rather
   than e.g. grep.</li>
 
   <li>If you get the argument type of an overloaded operator


### PR DESCRIPTION
I encountered this spelling mistake while reading the C++ style guide. Better fix it though it (really) doesn't matter at all.